### PR TITLE
Expose custom Launcher options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
             <plugin>
                 <groupId>de.sormuras.junit</groupId>
                 <artifactId>junit-platform-maven-plugin</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>1.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <isolation>NONE</isolation>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>de.sormuras.junit</groupId>
             <artifactId>junit-platform-isolator</artifactId>
-            <version>1.0.0-M10</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 
@@ -281,7 +281,7 @@
             <plugin>
                 <groupId>de.sormuras.junit</groupId>
                 <artifactId>junit-platform-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <extensions>true</extensions>
                 <configuration>
                     <isolation>NONE</isolation>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>de.sormuras.junit</groupId>
             <artifactId>junit-platform-isolator</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-M11</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
@@ -108,6 +108,9 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
   /** Custom version map to override detected version. */
   @Parameter private Map<String, String> versions = emptyMap();
 
+  /** Custom Launcher options. */
+  @Parameter private LauncherOptions launcherOptions = new LauncherOptions();
+
   /** The underlying Maven build model. */
   @Parameter(defaultValue = "${project.build}", readonly = true, required = true)
   private Build mavenBuild;
@@ -393,6 +396,12 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
             .setFilterTags(tags)
             // configuration parameters
             .setParameters(parameters)
+            .end()
+            .launcher()
+            .setTestEngineAutoRegistration(launcherOptions.testEngineAutoRegistration)
+            .setTestExecutionListenerAutoRegistration(
+                launcherOptions.testExecutionListenerAutoRegistration)
+            .setAdditionalTestEngines(launcherOptions.additionalTestEngines)
             .end();
 
     // No custom selector configured?

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/LauncherOptions.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/LauncherOptions.java
@@ -1,0 +1,26 @@
+package de.sormuras.junit.platform.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.platform.launcher.Launcher;
+
+/**
+ * {@code LauncherOptions} defines the configuration API for creating {@link Launcher} instances.
+ */
+public class LauncherOptions {
+
+  /**
+   * Determine if test engines should be discovered at runtime using the {@link
+   * java.util.ServiceLoader ServiceLoader} mechanism and automatically registered.
+   */
+  boolean testEngineAutoRegistration = true;
+
+  /**
+   * Determine if test execution listeners should be discovered at runtime using the {@link
+   * java.util.ServiceLoader ServiceLoader} mechanism and automatically registered.
+   */
+  boolean testExecutionListenerAutoRegistration = true;
+
+  /** Collection of additional test engines that should be added to the {@link Launcher}. */
+  Collection<String> additionalTestEngines = new ArrayList<>();
+}


### PR DESCRIPTION
The goal of this change is to expose the Launcher configuration outside the maven plugin to give more fine-grained control over the TestEngine instances that are used in the test runs.