### PR TITLE
Add progress output during execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ Global timeout duration defaults to 300 seconds.
 </configuration>
 ```
 
+### Execution Progress
+
+Duration between output and error log file sizes during execution (JAVA execution mode only). Defaults to 60 seconds.
+
+```xml
+<configuration>
+  <executionProgress>60</executionProgress>
+</configuration>
+```
+
 ### Isolation Level
 
 `ClassLoader` hierarchy configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,7 @@
                                 <!--<pomInclude>modular-world-multi-modules</pomInclude>-->
                                 <!--<pomInclude>multiple-engines-*</pomInclude>-->
                                 <!--<pomInclude>timeout</pomInclude>-->
+                                <!--<pomInclude>executionProgress</pomInclude>-->
                             </pomIncludes>
                             <pomExcludes>
                                 <!-- None, B. -->

--- a/src/it/configured/verify.bsh
+++ b/src/it/configured/verify.bsh
@@ -17,6 +17,7 @@ verifier.verifyNotExists(new String[] {
 
 verifier.verifyLogMatches(new String[] {
   ">> BEGIN >>",
+  "[DEBUG]   (f) executionProgress = 60",
   "[DEBUG]   (f) executor = DIRECT",
   "[DEBUG]   (f) isolation = NONE",
   ">> More Maven parameters... >>",

--- a/src/it/execution-progress/invoker.properties
+++ b/src/it/execution-progress/invoker.properties
@@ -1,0 +1,2 @@
+
+invoker.buildResult=failure

--- a/src/it/execution-progress/pom.xml
+++ b/src/it/execution-progress/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>execution-progress</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <configuration>
+          <executor>JAVA</executor>
+          <executionProgress>2</executionProgress>
+          <timeout>3</timeout>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/execution-progress/src/test/java/ExecutionProgressTests.java
+++ b/src/it/execution-progress/src/test/java/ExecutionProgressTests.java
@@ -1,0 +1,12 @@
+import org.junit.jupiter.api.Test;
+
+class ExecutionProgressTests {
+
+  @Test
+  void count() throws Exception {
+    for (int i = 0; i < 300; i++) {
+      Thread.sleep(200);
+      System.out.println(i);
+    }
+  }
+}

--- a/src/it/execution-progress/verify.bsh
+++ b/src/it/execution-progress/verify.bsh
@@ -1,0 +1,30 @@
+import it.Verifier;
+
+Verifier verifier = new Verifier(basedir.toPath());
+
+// verifier.verifyBadLines(); // warning and error lines are expected
+
+verifier.verifyReadable(new String[] {
+  "pom.xml",
+  "src/test/java/ExecutionProgressTests.java",
+  "target/test-classes/ExecutionProgressTests.class"
+});
+
+verifier.verifyNotExists(new String[] {
+  "target/classes",
+  "target/surefire-reports"
+});
+
+verifier.verifyLogMatches(new String[] {
+  ">> BEGIN >>",
+  "[INFO] Launching JUnit Platform " + junitPlatformVersion + "...",
+  ">> Platform executes tests...>>",
+  "\\Q[INFO]\\E Output Log: .+ bytes, Error Log: .+ bytes",
+  "\\Q[INFO]\\E Output Log: .+ bytes, Error Log: .+ bytes",
+  "[WARNING] Global timeout of 3 second(s) reached.",
+  ">> Platform executes tests...>>",
+  "[INFO] BUILD FAILURE",
+  ">> END. >>"
+});
+
+return verifier.isOk();

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
@@ -92,6 +92,10 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
   @Parameter(defaultValue = "300")
   private long timeout = 300L;
 
+  /** Execution progress update duration in seconds. */
+  @Parameter(defaultValue = "60")
+  private long executionProgress = 60;
+
   /** Execution mode. */
   @Parameter(defaultValue = "DIRECT")
   private Executor executor = Executor.DIRECT;
@@ -513,6 +517,10 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
 
   long getTimeout() {
     return timeout;
+  }
+
+  long getExecutionProgress() {
+    return executionProgress;
   }
 
   boolean isDryRun() {

--- a/src/test/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojoTests.java
+++ b/src/test/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojoTests.java
@@ -33,6 +33,7 @@ class JUnitPlatformMojoTests {
     assertEquals(Executor.DIRECT, mojo.getExecutor());
     assertEquals(Isolation.NONE, mojo.getIsolation());
     assertEquals(300L, mojo.getTimeout());
+    assertEquals(60L, mojo.getExecutionProgress());
 
     assertNotNull(mojo.getLog());
     assertNull(mojo.getMavenProject());


### PR DESCRIPTION
The existing plugin captures all output to a log file and gives no indication to the user that anything is happening.  This adds a debug output during execution showing the size of the output and error logs, to give the user some measure of progress.

Still need to make this setting configurable, but wanted feedback on the approach before investing further effort.