### PR TITLE
Handle multi modules where one reactor project has no tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,13 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.codehaus.groovy</groupId>
+                                <artifactId>groovy</artifactId>
+                                <version>3.0.8</version>
+                            </dependency>
+                        </dependencies>
                         <configuration>
                             <debug>true</debug>
                             <addTestClassPath>true</addTestClassPath>

--- a/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/pom.xml
+++ b/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>multi-mods</groupId>
+    <artifactId>modular-multi-modules-no-tests</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>module-with-both-sources-and-tests</artifactId>
+
+</project>

--- a/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/main/java/module-info.java
+++ b/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module app1 {
+  exports multi.mods.firstapp;
+}

--- a/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/main/java/multi/mods/firstapp/App1.java
+++ b/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/main/java/multi/mods/firstapp/App1.java
@@ -1,0 +1,7 @@
+package multi.mods.firstapp;
+
+public class App1 {
+  public boolean returnTrue() {
+    return true;
+  }
+}

--- a/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/test/java/module-info.test
+++ b/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/test/java/module-info.test
@@ -1,0 +1,5 @@
+--add-reads
+  app1=org.junit.jupiter.api
+
+--add-opens
+  app1/multi.mods.firstapp=org.junit.platform.commons

--- a/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/test/java/multi/mods/firstapp/App1Test.java
+++ b/src/it/modular-multi-modules-no-tests/module-with-both-sources-and-tests/src/test/java/multi/mods/firstapp/App1Test.java
@@ -1,0 +1,12 @@
+package multi.mods.firstapp;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class App1Test {
+  @Test
+  void test_app1_returning_true() {
+    assertTrue(new App1().returnTrue());
+  }
+}

--- a/src/it/modular-multi-modules-no-tests/module-with-only-sources/pom.xml
+++ b/src/it/modular-multi-modules-no-tests/module-with-only-sources/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>multi-mods</groupId>
+    <artifactId>modular-multi-modules-no-tests</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>module-with-only-sources</artifactId>
+
+</project>

--- a/src/it/modular-multi-modules-no-tests/module-with-only-sources/src/main/java/module-info.java
+++ b/src/it/modular-multi-modules-no-tests/module-with-only-sources/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module app2 {
+  exports multi.mods.secondapp;
+}

--- a/src/it/modular-multi-modules-no-tests/module-with-only-sources/src/main/java/multi/mods/secondapp/App2.java
+++ b/src/it/modular-multi-modules-no-tests/module-with-only-sources/src/main/java/multi/mods/secondapp/App2.java
@@ -1,0 +1,7 @@
+package multi.mods.secondapp;
+
+public class App2 {
+  public boolean returnTrue() {
+    return true;
+  }
+}

--- a/src/it/modular-multi-modules-no-tests/pom.xml
+++ b/src/it/modular-multi-modules-no-tests/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <groupId>multi-mods</groupId>
+  <artifactId>modular-multi-modules-no-tests</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-with-both-sources-and-tests</module>
+    <module>module-with-only-sources</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <configuration>
+          <isolation>NONE</isolation>
+          <executor>JAVA</executor>
+          <javaOptions>
+            <additionalOptions>
+              <additionalOption>--show-version</additionalOption>
+              <additionalOption>--show-module-resolution</additionalOption>
+            </additionalOptions>
+          </javaOptions>
+          <tweaks>
+            <skipOnMissingTestOutputDirectory>true</skipOnMissingTestOutputDirectory>
+          </tweaks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/modular-multi-modules-no-tests/pom.xml
+++ b/src/it/modular-multi-modules-no-tests/pom.xml
@@ -42,7 +42,7 @@
             </additionalOptions>
           </javaOptions>
           <tweaks>
-            <skipOnMissingTestOutputDirectory>true</skipOnMissingTestOutputDirectory>
+            <failIfNoTests>false</failIfNoTests>
           </tweaks>
         </configuration>
       </plugin>

--- a/src/it/modular-multi-modules-no-tests/prebuild.groovy
+++ b/src/it/modular-multi-modules-no-tests/prebuild.groovy
@@ -1,0 +1,14 @@
+import it.Verifier
+
+def verifier = new Verifier(basedir.toPath())
+
+verifier.verifyReadable "pom.xml",
+  "module-with-both-sources-and-tests/pom.xml",
+  "module-with-both-sources-and-tests/src/main/java/module-info.java",
+  "module-with-both-sources-and-tests/src/test/java/module-info.test",
+  "module-with-only-sources/pom.xml",
+  "module-with-only-sources/src/main/java/module-info.java"
+
+verifier.verifyNotExists "module-with-only-sources/src/test/java/module-info.test"
+
+verifier.isOk()

--- a/src/it/modular-multi-modules-no-tests/verify.groovy
+++ b/src/it/modular-multi-modules-no-tests/verify.groovy
@@ -4,6 +4,12 @@ def verifier = new Verifier(basedir.toPath())
 
 verifier.verifyBadLines()
 
-// TODO add verifier.verifyLogMatches invocation
+verifier.verifyLogMatches ">> BEGIN >>",
+  "    <failIfNoTests>false</failIfNoTests>",
+  ">> A bunch of log lines... >>",
+  "\\Q[DEBUG] Patched directory \\E.*/module-with-only-sources/target/junit-platform/patched-test-runtime was not found and failIfNoTests is set to false",
+  ">> A bunch of log lines... >>",
+  "[INFO] BUILD SUCCESS",
+  ">> END. >>"
 
 verifier.isOk()

--- a/src/it/modular-multi-modules-no-tests/verify.groovy
+++ b/src/it/modular-multi-modules-no-tests/verify.groovy
@@ -1,0 +1,9 @@
+import it.Verifier
+
+def verifier = new Verifier(basedir.toPath())
+
+verifier.verifyBadLines()
+
+// TODO add verifier.verifyLogMatches invocation
+
+verifier.isOk()

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/MavenDriver.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/MavenDriver.java
@@ -131,9 +131,16 @@ class MavenDriver implements Driver {
       File testDirectory = new File(project.getBuild().getTestOutputDirectory());
       try {
         FileUtils.copyDirectoryStructure(mainDirectory, patched.toFile());
-        FileUtils.copyDirectoryStructure(testDirectory, patched.toFile());
       } catch (IOException e) {
         throw new UncheckedIOException("Populating patched directory failed: " + patched, e);
+      }
+      try {
+        FileUtils.copyDirectoryStructure(testDirectory, patched.toFile());
+      } catch (IOException e) {
+        if (tweaks.failIfNoTests) {
+          throw new UncheckedIOException("Populating patched directory failed: " + patched, e);
+        }
+        debug("Patched directory {0} was not found and failIfNoTests is set to false", patched);
       }
     }
 


### PR DESCRIPTION
Added integration test as ﻿a follow up for [this discussion](https://github.com/sormuras/junit-platform-maven-plugin/discussions/74).

Notes:

- The prebuild and verifier scripts were written in `groovy`.
  To avoid the wrong version popping up, I've added the groovy dependency to the invoker plugin configuration.
  If this is not cool, I'll go back to `beanshell` and force push.

- The integration test currently fails, as expected.
  For the record, removing the `module-info` descriptors, makes it pass.

- There's a TODO comment in the verifier script, as a reminder to add log verifications.
  I will handle it once we get this integration test to pass.
