### PR TITLE
The `classNamePatterns` option breaks test execution

### DIFF
--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
@@ -243,7 +243,7 @@ class JavaExecutor {
 
     Optional<Object> mainModule = modules.getMainModuleReference();
     Optional<Object> testModule = modules.getTestModuleReference();
-    if (mojo.getTest() == null && dsc.getFilterClassNamePatterns() == null) {
+    if (mojo.getTest() == null) {
       if (testModule.isPresent()) {
         cmd.add("--select-module");
         cmd.add(modules.getTestModuleName().orElseThrow(AssertionError::new));


### PR DESCRIPTION
I'm trying to integrate this plugin into my workflow. It seems to be the only right way for testing in JPMS world. Thanks!

However I discovered one issue: when I specify the `classNamePatterns` option the build fails with `RED ALERT`. The detailed exception is

```
org.junit.platform.commons.PreconditionViolationException: No arguments were supplied to the ConsoleLauncher
	at org.junit.platform.commons@1.9.1/org.junit.platform.commons.util.Preconditions.condition(Preconditions.java:299)
	at org.junit.platform.commons@1.9.1/org.junit.platform.commons.util.Preconditions.notEmpty(Preconditions.java:144)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.DiscoveryRequestCreator.createDiscoverySelectors(DiscoveryRequestCreator.java:72)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.DiscoveryRequestCreator.toDiscoveryRequest(DiscoveryRequestCreator.java:53)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.ConsoleTestExecutor.executeTests(ConsoleTestExecutor.java:65)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.ConsoleTestExecutor.lambda$execute$0(ConsoleTestExecutor.java:58)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.CustomContextClassLoaderExecutor.invoke(CustomContextClassLoaderExecutor.java:33)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.tasks.ConsoleTestExecutor.execute(ConsoleTestExecutor.java:58)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.ConsoleLauncher.executeTests(ConsoleLauncher.java:120)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:82)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:55)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:48)
	at org.junit.platform.console@1.9.1/org.junit.platform.console.ConsoleLauncher.main(ConsoleLauncher.java:42)
```

That happens because the `JavaExecutor` checks—when it is suppose to generate test classes to be executed—whether `classNamePatterns` are specified or not. If so the generation of test classes to be executed is completely skipped leading to the Invalid Usage error.

This patch removes the `classNamePatterns` condition.

### Rationale

- In the stage when `classNamePatterns` are being populated to the CLI it is surrounded by a check for interactive/non-interactive execution. In fact the mode is clearly non-interactive at that stage.
- The second check for non-interactive mode (the condition addressed by this patch) is just a safety guard so the non-interactive (directory/classes/module) do not clash with already presented explicit classes (from the interactive).
- The `classNamePatterns` can appear only if interactive mode is not in question.
- The (second) guard for non-interactivity does not need to deal with `classNamePatterns` and should not be driven by that option.

Hope it makes sense.
