### PR TITLE
Delete previous patched-test-runtime directory before copying if it exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [18]
+        java: [19]
 
     steps:
       - name: 'Check out sources'


### PR DESCRIPTION
Running `mvn test` multiple times without a `clean` on a modular project fails, because the code attempts to copy the "patched-test-runtime" directory, which fails if it is not empty. 

This PR deletes that directory and its contents before attempting the file copy.

Tests and integration tests still pass after this change.

Fixes #94 
Fixes #100 

This contribution is my original work and I license the work to the project under the project's open source license.