### PR TITLE
Update CI to JDK 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [18]
+        java: [19]
 
     steps:
       - name: 'Check out sources'


### PR DESCRIPTION
CI GitHub Action is failing because it's set for JDK 18 which is now a year old (Happy Birthday!) but no longer supported.  Per the [docs](https://github.com/oracle-actions/setup-java):
> Note also that websites may stop offering any release at any time. Please consult the website for details which release is offered for how long.

Currently JDK 19, 20 and 21-ea are available.  

This PR attempted to update CI to JDK 20, released 5 days ago.  However, tests failed on jacoco something-or-other and my attempts to access the log uploads to further debug failed.  

Turns out despite no longer being supported, JDK 19 works.

This contribution is my original work and I license the work to the project under the project's open source license.