### PR TITLE
fix: jacoco plugin 0.8.9-SNAPSHOT is inaccessible

### DIFF
--- a/src/it/jacoco-executor-java/pom.xml
+++ b/src/it/jacoco-executor-java/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.9-SNAPSHOT</version>
+                <version>0.8.11-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tomer@tomfi.info>
