### PR TITLE
test: added mockito modular integration tests

### DIFF
--- a/src/it/mockito-modular/mockito-modular-v4-attach/pom.xml
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>mockito-modular</groupId>
+    <artifactId>mockito-modular-parent</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>mockito-modular-v4-attach</artifactId>
+
+  <properties>
+    <mockito.version>4.11.0</mockito.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/mockitov4attach/AppInterface.java
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/mockitov4attach/AppInterface.java
@@ -1,0 +1,5 @@
+package mockitov4attach;
+
+public interface AppInterface {
+  public boolean running();
+}

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/mockitov4attach/AppRunner.java
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/mockitov4attach/AppRunner.java
@@ -1,0 +1,13 @@
+package mockitov4attach;
+
+public final class AppRunner {
+  private final AppInterface runningApp;
+
+  public AppRunner(final AppInterface appToRun) {
+    runningApp = appToRun;
+  }
+
+  public boolean isAppRunning() {
+    return runningApp.running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/module-info.java
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module mockito.modular.v4.attach {
+  exports mockitov4attach;
+}

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/mockitov4attach/App_Runner_Test.java
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/mockitov4attach/App_Runner_Test.java
@@ -1,0 +1,23 @@
+package mockitov4attach;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class App_Runner_Test {
+  @Mock private AppInterface mockApp;
+  @InjectMocks private AppRunner sut;
+
+  @Test
+  void checking_the_runner_if_the_app_is_running_should_invoke_the_underlying_app() {
+    given(mockApp.running()).willReturn(true);
+    assert sut.isAppRunning();
+    then(mockApp).should().running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/module-info.test
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/module-info.test
@@ -1,0 +1,7 @@
+--add-modules
+  jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
+
+--add-opens
+  mockito.modular.v4.attach/mockitov4attach=org.junit.platform.commons
+--add-opens
+  mockito.modular.v4.attach/mockitov4attach=org.mockito

--- a/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/module-info.test
+++ b/src/it/mockito-modular/mockito-modular-v4-attach/src/test/java/module-info.test
@@ -1,5 +1,5 @@
 --add-modules
-  jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
+  jdk.attach,jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
 
 --add-opens
   mockito.modular.v4.attach/mockitov4attach=org.junit.platform.commons

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/pom.xml
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>mockito-modular</groupId>
+    <artifactId>mockito-modular-parent</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>mockito-modular-v4-subclass</artifactId>
+
+  <properties>
+    <mockito.version>4.11.0</mockito.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/mockitov4subclass/AppInterface.java
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/mockitov4subclass/AppInterface.java
@@ -1,0 +1,5 @@
+package mockitov4subclass;
+
+public interface AppInterface {
+  public boolean running();
+}

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/mockitov4subclass/AppRunner.java
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/mockitov4subclass/AppRunner.java
@@ -1,0 +1,13 @@
+package mockitov4subclass;
+
+public final class AppRunner {
+  private final AppInterface runningApp;
+
+  public AppRunner(final AppInterface appToRun) {
+    runningApp = appToRun;
+  }
+
+  public boolean isAppRunning() {
+    return runningApp.running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/module-info.java
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module mockito.modular.v4.subclass {
+  exports mockitov4subclass;
+}

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/src/test/java/mockitov4subclass/App_Runner_Test.java
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/src/test/java/mockitov4subclass/App_Runner_Test.java
@@ -1,0 +1,23 @@
+package mockitov4subclass;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class App_Runner_Test {
+  @Mock private AppInterface mockApp;
+  @InjectMocks private AppRunner sut;
+
+  @Test
+  void checking_the_runner_if_the_app_is_running_should_invoke_the_underlying_app() {
+    given(mockApp.running()).willReturn(true);
+    assert sut.isAppRunning();
+    then(mockApp).should().running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v4-subclass/src/test/java/module-info.test
+++ b/src/it/mockito-modular/mockito-modular-v4-subclass/src/test/java/module-info.test
@@ -1,0 +1,7 @@
+--add-modules
+  jdk.unsupported,org.mockito,net.bytebuddy
+
+--add-opens
+  mockito.modular.v4.subclass/mockitov4subclass=org.junit.platform.commons
+--add-opens
+  mockito.modular.v4.subclass/mockitov4subclass=org.mockito

--- a/src/it/mockito-modular/mockito-modular-v5-attach/pom.xml
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>mockito-modular</groupId>
+    <artifactId>mockito-modular-parent</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>mockito-modular-v5-attach</artifactId>
+
+  <properties>
+    <mockito.version>5.3.1</mockito.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/mockitov5attach/AppInterface.java
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/mockitov5attach/AppInterface.java
@@ -1,0 +1,5 @@
+package mockitov5attach;
+
+public interface AppInterface {
+  public boolean running();
+}

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/mockitov5attach/AppRunner.java
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/mockitov5attach/AppRunner.java
@@ -1,0 +1,13 @@
+package mockitov5attach;
+
+public final class AppRunner {
+  private final AppInterface runningApp;
+
+  public AppRunner(final AppInterface appToRun) {
+    runningApp = appToRun;
+  }
+
+  public boolean isAppRunning() {
+    return runningApp.running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/module-info.java
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module mockito.modular.v5.attach {
+  exports mockitov5attach;
+}

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/mockitov5attach/App_Runner_Test.java
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/mockitov5attach/App_Runner_Test.java
@@ -1,0 +1,23 @@
+package mockitov5attach;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class App_Runner_Test {
+  @Mock private AppInterface mockApp;
+  @InjectMocks private AppRunner sut;
+
+  @Test
+  void checking_the_runner_if_the_app_is_running_should_invoke_the_underlying_app() {
+    given(mockApp.running()).willReturn(true);
+    assert sut.isAppRunning();
+    then(mockApp).should().running();
+  }
+}

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/module-info.test
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/module-info.test
@@ -1,0 +1,7 @@
+--add-modules
+  jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
+
+--add-opens
+  mockito.modular.v5.attach/mockitov5attach=org.junit.platform.commons
+--add-opens
+  mockito.modular.v5.attach/mockitov5attach=org.mockito

--- a/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/module-info.test
+++ b/src/it/mockito-modular/mockito-modular-v5-attach/src/test/java/module-info.test
@@ -1,5 +1,5 @@
 --add-modules
-  jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
+  jdk.attach,jdk.unsupported,org.mockito,net.bytebuddy,net.bytebuddy.agent
 
 --add-opens
   mockito.modular.v5.attach/mockitov5attach=org.junit.platform.commons

--- a/src/it/mockito-modular/pom.xml
+++ b/src/it/mockito-modular/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <groupId>mockito-modular</groupId>
+  <artifactId>mockito-modular-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>mockito-modular-v4-subclass</module> <!-- using mockito.core, v4 defaults to subclassing -->
+    <module>mockito-modular-v4-attach</module> <!-- using mockito.inline for using attaching in v4 -->
+    <module>mockito-modular-v5-attach</module> <!-- using mockito.core, v5 defaults to attaching -->
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <executor>JAVA</executor>
+          <javaOptions>
+            <additionalOptions>
+              <additionalOption>--show-version</additionalOption>
+              <additionalOption>--show-module-resolution</additionalOption>
+            </additionalOptions>
+          </javaOptions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/mockito-modular/verify.groovy
+++ b/src/it/mockito-modular/verify.groovy
@@ -1,0 +1,13 @@
+import it.Verifier
+
+def verifier = new Verifier(basedir.toPath())
+
+verifier.verifyBadLines();
+
+verifier.verifyLogMatches ">> BEGIN >>",
+  "[INFO] Launching JUnit Platform " + junitPlatformVersion + "...",
+  ">> Platform executes tests...>>",
+  "[INFO] BUILD SUCCESS",
+  ">> END. >>"
+
+verifier.isOk()


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tomer@tomfi.info>

[v5.0.0](https://github.com/mockito/mockito/releases/tag/v5.0.0) was a milestone release for Mockito.
The default mock maker was replaced from `mock-subclass` to `mock-inline`.

Unfortunately, this broke this plugin.

This PR doesn't fix anything, rather it introduces two identical modular integration tests.
One running the current latest v4.x version, [v4.11.0](https://github.com/mockito/mockito/releases/tag/v4.11.0) and **executes successfully**.
And one running the current latest v5.x version [v.5.3.1](https://github.com/mockito/mockito/releases/tag/v5.3.1) and **fails**.
Throwing exceptions in regards to the `mock maker` creation and `bytebuddy`.

Looking into [mockito's issues](https://github.com/mockito/mockito/issues?q=is%3Aissue+Could+not+initialize+inline+Byte+Buddy+mock+maker), it doesn't look like we're the only ones experiencing this.
It is not yet clear if it's a `mockito` issue, a `bytebuddy` issue, a `java` version issue, or simply some tweaking of the `module-info.test` is required. Might even be something we need to change on the plugin end.
Regardless, these integration tests should be merged once this is resolved.

> Mockito v5.3.1 is used in the integration tests. But I verified on my end this break starts with version 5.0.0.

