### PR TITLE
Add charset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ Duration between output and error log file sizes during execution (JAVA executio
 </configuration>
 ```
 
+### Log Charset
+
+Charset format for the output and error log files. Defaults to `Charset.defaultCharset()` for JDK 17 and lower, `System.getProperty("native.encoding")` for JDK 18 and higher.
+
+```xml
+<configuration>
+  <charset>UTF-8</charset>
+</configuration>
+```
+
 ### Isolation Level
 
 `ClassLoader` hierarchy configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
                                 <!--<pomInclude>multiple-engines-*</pomInclude>-->
                                 <!--<pomInclude>timeout</pomInclude>-->
                                 <!--<pomInclude>executionProgress</pomInclude>-->
+                                <!--<pomInclude>charset</pomInclude>-->
                             </pomIncludes>
                             <pomExcludes>
                                 <!-- None, B. -->

--- a/src/it/charset/pom.xml
+++ b/src/it/charset/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>execution-progress</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <configuration>
+          <executor>JAVA</executor>
+          <charset>ISO-8859-1</charset>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/charset/src/test/java/CharsetTests.java
+++ b/src/it/charset/src/test/java/CharsetTests.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+
+class CharsetTests {
+
+  @Test
+  void outputSomething() throws Exception {
+    System.out.println("UTF-8 degree sign is °");
+  }
+}

--- a/src/it/charset/src/test/java/CharsetTests.java
+++ b/src/it/charset/src/test/java/CharsetTests.java
@@ -4,6 +4,8 @@ class CharsetTests {
 
   @Test
   void outputSomething() throws Exception {
+    // The degree sign (hex b0) will be prepended by 2c in UTF-8
+    // For ISO output check for optional Â (hex 2c) character
     System.out.println("UTF-8 degree sign is °");
   }
 }

--- a/src/it/charset/verify.bsh
+++ b/src/it/charset/verify.bsh
@@ -19,7 +19,7 @@ verifier.verifyLogMatches(new String[] {
   ">> BEGIN >>",
   "[INFO] Launching JUnit Platform " + junitPlatformVersion + "...",
   ">> Platform executes tests...>>",
-  "\\Q[INFO]\\E UTF-8 degree sign is Â°",
+  "\\Q[INFO]\\E UTF-8 degree sign is Â?°",
   ">> Platform executes tests...>>",
   "[INFO] BUILD SUCCESS",
   ">> END. >>"

--- a/src/it/charset/verify.bsh
+++ b/src/it/charset/verify.bsh
@@ -1,0 +1,28 @@
+import it.Verifier;
+
+Verifier verifier = new Verifier(basedir.toPath());
+
+// verifier.verifyBadLines(); // warning and error lines are expected
+
+verifier.verifyReadable(new String[] {
+  "pom.xml",
+  "src/test/java/CharsetTests.java",
+  "target/test-classes/CharsetTests.class"
+});
+
+verifier.verifyNotExists(new String[] {
+  "target/classes",
+  "target/surefire-reports"
+});
+
+verifier.verifyLogMatches(new String[] {
+  ">> BEGIN >>",
+  "[INFO] Launching JUnit Platform " + junitPlatformVersion + "...",
+  ">> Platform executes tests...>>",
+  "\\Q[INFO]\\E UTF-8 degree sign is Â°",
+  ">> Platform executes tests...>>",
+  "[INFO] BUILD SUCCESS",
+  ">> END. >>"
+});
+
+return verifier.isOk();

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojo.java
@@ -92,6 +92,10 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
   @Parameter(defaultValue = "300")
   private long timeout = 300L;
 
+  /** Charset for log files. */
+  @Parameter(defaultValue = "")
+  private String charset = null;
+
   /** Execution progress update duration in seconds. */
   @Parameter(defaultValue = "60")
   private long executionProgress = 60;
@@ -506,6 +510,10 @@ public class JUnitPlatformMojo extends AbstractMavenLifecycleParticipant impleme
 
   long getTimeout() {
     return timeout;
+  }
+
+  String getCharset() {
+    return charset;
   }
 
   long getExecutionProgress() {

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
@@ -19,6 +19,7 @@ import de.sormuras.junit.platform.isolator.Modules;
 import de.sormuras.junit.platform.isolator.TestMode;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -152,11 +153,14 @@ class JavaExecutor {
           mojo.warn("Reading output/error logs failed: {0}", e);
         }
       }
-      return exitValue;
+    } catch (CharacterCodingException cce) {
+      // Possibly thrown from Files.lines and not caught above
+      mojo.warn("Charset error reading output/error logs: {0}", cce);
     } catch (IOException | InterruptedException e) {
       mojo.error("Executing process failed: {0}", e);
       return -1;
     }
+    return exitValue;
   }
 
   // Supply standard options for Java foundation tool

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
@@ -139,7 +139,10 @@ class JavaExecutor {
       }
       int exitValue = process.exitValue();
       if (captureIO) {
-        String encoding = System.getProperty("native.encoding"); // Populated on Java 18 and later
+        String encoding = mojo.getCharset();
+        if (encoding == null) {
+          encoding = System.getProperty("native.encoding"); // Populated on Java 18 and later
+        }
         Charset charset = encoding != null ? Charset.forName(encoding) : Charset.defaultCharset();
         try (Stream<String> stdoutput = Files.lines(outputPath, charset);
             Stream<String> erroutput = Files.lines(errorPath, charset)) {

--- a/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
+++ b/src/main/java/de/sormuras/junit/platform/maven/plugin/JavaExecutor.java
@@ -102,6 +102,7 @@ class JavaExecutor {
     mojo.debug("");
     mojo.debug("Starting process...");
     cmd.forEach(mojo::debug);
+    int exitValue = -1;
     try {
       Process process = builder.start();
       // Java 11 debug("Process started: #%d %s", process.pid(), process.info());
@@ -138,7 +139,7 @@ class JavaExecutor {
         }
         return -2;
       }
-      int exitValue = process.exitValue();
+      exitValue = process.exitValue();
       if (captureIO) {
         String encoding = mojo.getCharset();
         if (encoding == null) {

--- a/src/test/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojoTests.java
+++ b/src/test/java/de/sormuras/junit/platform/maven/plugin/JUnitPlatformMojoTests.java
@@ -34,6 +34,7 @@ class JUnitPlatformMojoTests {
     assertEquals(Isolation.NONE, mojo.getIsolation());
     assertEquals(300L, mojo.getTimeout());
     assertEquals(60L, mojo.getExecutionProgress());
+    assertNull(mojo.getCharset());
 
     assertNotNull(mojo.getLog());
     assertNull(mojo.getMavenProject());


### PR DESCRIPTION
Allows user to override Java default charset when printing logs, to work around MalformedInputExceptions.

Fixes #115

This contribution is my original work and I license the work to the project under the project's open source license.